### PR TITLE
Add Frida tracing functionality

### DIFF
--- a/RemoteNetSpy/MainWindow.xaml
+++ b/RemoteNetSpy/MainWindow.xaml
@@ -481,6 +481,12 @@
                                                 <TextBlock Padding="0,0" Margin="5,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Center">Start Trace</TextBlock>
                                             </StackPanel>
                                         </Button>
+                                        <Button Click="RunFridaTracesButtonClicked" Padding="5,0" Margin="0,2" MinHeight="21">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <Image Source="icons/Run.png" Height="16"/>
+                                                <TextBlock Padding="0,0" Margin="5,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Center">Trace with Frida</TextBlock>
+                                            </StackPanel>
+                                        </Button>
                                         <Button Padding="2,0" Margin="2,2" MinHeight="21" Click="OpenTraceListClicked">
                                             <Image Source="icons/OpenFolder.png" Height="16"/>
                                         </Button>
@@ -492,7 +498,7 @@
                                         </Button>
                                         <Button Padding="5,0" Margin="2,2" Click="ManualTraceClicked" Visibility="Collapsed">Manual Trace</Button>
                                     </StackPanel>
-                                    <ListBox x:Name="tracesListBox">
+                                    <ListBox x:Name="tracesListBox" DisplayMemberPath="DemangledName">
                                         <ListBox.ItemTemplate>
                                             <DataTemplate>
                                                 <DockPanel>
@@ -502,7 +508,7 @@
                                                         </ContextMenu>
                                                     </DockPanel.ContextMenu>
                                                     <Image Source="/icons/NewMethod.png" Margin="0,0,3,0"/>
-                                                    <TextBlock Text="{Binding Path=.}" />
+                                                    <TextBlock Text="{Binding Path=DemangledName}" />
                                                 </DockPanel>
                                             </DataTemplate>
                                         </ListBox.ItemTemplate>

--- a/RemoteNetSpy/Models/TraceFunction.cs
+++ b/RemoteNetSpy/Models/TraceFunction.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace RemoteNetSpy.Models
+{
+    public class TraceFunction
+    {
+        public string DemangledName { get; set; }
+        public string MangledName { get; set; }
+
+        public TraceFunction(string demangledName, string mangledName)
+        {
+            DemangledName = demangledName;
+            MangledName = mangledName;
+        }
+
+        public string ToJson()
+        {
+            return JsonSerializer.Serialize(this);
+        }
+
+        public static TraceFunction FromJson(string json)
+        {
+            return JsonSerializer.Deserialize<TraceFunction>(json);
+        }
+
+        public void SaveToFile(string filePath)
+        {
+            File.WriteAllText(filePath, ToJson());
+        }
+
+        public static TraceFunction LoadFromFile(string filePath)
+        {
+            string json = File.ReadAllText(filePath);
+            return FromJson(json);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #29

Add Frida tracing functionality to the tracing tab in RemoteNetSpy.

* **New Button and Event Handler**
  - Add a new button labeled 'Trace with Frida' in the tracing tab in `RemoteNetSpy/MainWindow.xaml`.
  - Implement `RunFridaTracesButtonClicked` method in `RemoteNetSpy/MainWindow.xaml.cs` to run `frida-trace` with the given list of functions to trace.
* **TraceFunction Class**
  - Add `TraceFunction` class in `RemoteNetSpy/Models/TraceFunction.cs` to store demangled and mangled names.
  - Implement serialization and deserialization methods for `TraceFunction` class.
* **Update Traces ListBox**
  - Update `tracesListBox` in `RemoteNetSpy/MainWindow.xaml` to store instances of `TraceFunction`.
  - Modify `SaveTraceFunctionsList` and `OpenTraceListClicked` methods in `RemoteNetSpy/MainWindow.xaml.cs` to handle serialization and deserialization of `TraceFunction` objects.
* **Enable/Disable Frida Button**
  - Update `procsBox_SelectionChanged` method in `RemoteNetSpy/MainWindow.xaml.cs` to disable the Frida tracing button for managed apps.
* **Trace List Handling**
  - Modify `MemberListItemMouseDown` method to add `TraceFunction` instances to `_traceList`.
  - Update `TraceLineDelete_OnClick` method to remove `TraceFunction` instances from `_traceList`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theXappy/rnet-kit/pull/30?shareId=d84c037f-ca10-46de-b5c0-c6827007d502).