### PR TITLE
Refactor target process selection

### DIFF
--- a/RemoteNetSpy/MainWindow.xaml
+++ b/RemoteNetSpy/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="RemoteNetSpy.MainWindow"
+<Window x:Class="RemoteNetSpy.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -68,62 +68,7 @@
         <DockPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3">
             <DockPanel DockPanel.Dock="Top" Margin="5">
                 <TextBlock DockPanel.Dock="Left" Margin="4,0,4,0" VerticalAlignment="Center">Target:</TextBlock>
-                <DockPanel>
-                    <Button x:Name="procsRefreshButton" DockPanel.Dock="Right" MinWidth="25" Margin="4,0,0,0" Click="ProcsRefreshButton_OnClick" BorderBrush="#FF3C3C3C">
-                        <Image Source="icons/Refresh.png" Stretch="None"/>
-                    </Button>
-                    <Grid>
-                        <Border x:Name="procsBoxBorder">
-                            <ComboBox x:Name="procsBox" SelectionChanged="procsBox_SelectionChanged" FontFamily="Consolas"
-                                  IsTextSearchEnabled="True" TextSearch.TextPath="Name"
-                                  Margin="4,0"
-                                  >
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate DataType="{x:Type models:InjectableProcess}">
-                                        <DockPanel>
-                                            <DockPanel.Width>
-                                                <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ComboBox}" Path="ActualWidth" Converter="{StaticResource comboBoxWidthAdjustmentConverter}"/>
-                                            </DockPanel.Width>
-                                            <!--<Image Source="/icons/ModulePublic.png" Margin="0,0,3,0"/>-->
-                                            <TextBlock Text="{Binding Path=Name}" Margin="0,0,10,0" />
-                                            <StackPanel Orientation="Horizontal" Margin="0,0,10,0" >
-                                                <TextBlock Text="(" />
-                                                <TextBlock Text="{Binding Path=Pid}" />
-                                                <TextBlock Text=")" />
-                                            </StackPanel>
-                                            <TextBlock Text="{Binding Path=DotNetVersion}" Margin="0,0,10,0" Foreground="{Binding Path=DotNetVersion, Converter={StaticResource dotnetVersionToForegroundColor}}"/>
-                                            <TextBlock Text="{Binding Path=DiverState}" Foreground="Aquamarine" />
-                                            <TextBlock DockPanel.Dock="Right" 
-                                                       Text=" &lt;&lt; PROCESS DIED >> "
-                                                       HorizontalAlignment="Right"
-                                                       Foreground="Crimson" 
-                                                       Background="Black"
-                                                       Padding="60,0"
-                                                       Margin="10,0"
-                                                       Visibility="{Binding Path=IsProcessDead, Converter={StaticResource boolToCollapsabilityConverter}}"/>
-                                        </DockPanel>
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                                <ComboBox.ItemContainerStyle>
-                                    <Style TargetType="{x:Type ComboBoxItem}">
-                                        <Setter Property="TextSearch.Text" Value="{Binding Name}" />
-                                    </Style>
-                                </ComboBox.ItemContainerStyle>
-                            </ComboBox>
-                        </Border>
-                        <TextBlock x:Name="procsBoxLoadingOverlay"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               Visibility="Collapsed"
-                               d:Visibility="Visible"
-                               DockPanel.Dock="Left"
-                               Padding="4,0"
-                               >
-                            <TextBlock.Text>Loading...</TextBlock.Text>
-                        </TextBlock>
-                        <remoteNetSpy:Spinner x:Name="processConnectionSpinner" Margin="1" Visibility="Collapsed"/>
-                    </Grid>
-                </DockPanel>
+                <TextBlock x:Name="selectedTargetTextBlock" DockPanel.Dock="Left" Margin="4,0,4,0" VerticalAlignment="Center"/>
             </DockPanel>
             <ToolBarTray DockPanel.Dock="Top" Background="#22000000" Margin="2,0" Height="30">
                 <ToolBar BandIndex="3" Height="28" Margin="1,1">

--- a/RemoteNetSpy/Windows/TargetSelectionWindow.xaml
+++ b/RemoteNetSpy/Windows/TargetSelectionWindow.xaml
@@ -1,0 +1,19 @@
+<Window x:Class="RemoteNetSpy.Windows.TargetSelectionWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Target Selection" Height="200" Width="400">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <TextBlock Text="Select Target Process:" Margin="10" Grid.Row="0" Grid.Column="0"/>
+        <ComboBox x:Name="procsBox" Grid.Row="1" Grid.Column="0" Margin="10" SelectionChanged="ProcsBox_SelectionChanged"/>
+        <Button x:Name="procsRefreshButton" Content="Refresh" Grid.Row="2" Grid.Column="0" Margin="10" Click="ProcsRefreshButton_OnClick"/>
+        <TextBlock x:Name="procsBoxLoadingOverlay" Text="Loading..." HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed" Grid.Row="1" Grid.Column="0"/>
+    </Grid>
+</Window>

--- a/RemoteNetSpy/Windows/TargetSelectionWindow.xaml.cs
+++ b/RemoteNetSpy/Windows/TargetSelectionWindow.xaml.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using CliWrap;
+using CliWrap.Buffered;
+using RemoteNetSpy.Models;
+
+namespace RemoteNetSpy.Windows
+{
+    public partial class TargetSelectionWindow : Window
+    {
+        public InjectableProcess SelectedProcess { get; private set; }
+
+        public TargetSelectionWindow()
+        {
+            InitializeComponent();
+            Loaded += TargetSelectionWindow_Loaded;
+        }
+
+        private async void TargetSelectionWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            await RefreshProcessesList();
+        }
+
+        private async Task RefreshProcessesList()
+        {
+            procsBox.ItemsSource = null;
+            procsBox.IsEnabled = false;
+            procsBoxLoadingOverlay.Visibility = Visibility.Visible;
+
+            try
+            {
+                CommandTask<BufferedCommandResult> commandTask = CliWrap.Cli.Wrap("rnet-ps.exe").ExecuteBufferedAsync();
+                BufferedCommandResult runResults = await commandTask.Task;
+                IEnumerable<string[]> splitLines = runResults.StandardOutput.Split('\n')
+                    .Skip(1)
+                    .ToList()
+                    .Select(line => line.Split('\t', StringSplitOptions.TrimEntries).ToArray())
+                    .Where(arr => arr.Length > 2);
+
+                List<InjectableProcess> procs = new();
+                foreach (string[] splitLine in splitLines)
+                {
+                    int pid = int.Parse(splitLine[0]);
+                    string name = splitLine[1];
+                    string runtimeVersion = splitLine[2]; // .NET version or "native" for C/C++/Unknown
+                    string diverState = splitLine[3];
+                    InjectableProcess proc = new(pid, name, runtimeVersion, diverState);
+
+                    procs.Add(proc);
+                }
+                procsBox.ItemsSource = procs;
+                procsBox.IsEnabled = true;
+                procsBoxLoadingOverlay.Visibility = Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to refresh processes list.\nException: " + ex, this.Title, MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void ProcsBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (procsBox.SelectedIndex == -1)
+                return;
+
+            SelectedProcess = procsBox.SelectedItem as InjectableProcess;
+            DialogResult = true;
+            Close();
+        }
+
+        private async void ProcsRefreshButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            await RefreshProcessesList();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #34

Refactor the process selection logic from `MainWindow` to a new `TargetSelectionWindow`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theXappy/rnet-kit/pull/35?shareId=bd8573b8-747a-48c0-8fa0-0aa277fa731b).